### PR TITLE
Fix timezone for non-EST users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,9 +61,9 @@ Before you can use the project's software, you have to setup an account with Goo
 
 Download your Google Calendar API application's `client_secret.json` file in the project folder. Be sure to name the downloaded file using that file name. You'll need it to authorize the app to access your Google Calendar and that file name is hard coded into the Python app.
 
-As part of that process, you'll install the [Google Calendar API Python files](https://developers.google.com/api-client-library/python/start/installation) using the following command:
+As part of that process, you'll install the [Google Calendar API Python files](https://developers.google.com/api-client-library/python/start/installation) along with date handling libraries using the following command:
 
-    sudo pip install --upgrade google-api-python-client
+    sudo pip install --upgrade google-api-python-client dateutils
 
 Install the Unicorn HAT libraries following the instructions on the [Pimoroni web site](http://learn.pimoroni.com/tutorial/unicorn-hat/getting-started-with-unicorn-hat):
 basically opening a terminal window and executing the following command:

--- a/remind.py
+++ b/remind.py
@@ -24,12 +24,14 @@ import math
 import os
 import sys
 import time
+import pytz
 
 import httplib2
 import numpy as np
 import oauth2client
 import unicornhat as lights
 from apiclient import discovery
+from dateutil import parser
 from oauth2client import client
 from oauth2client import tools
 
@@ -219,7 +221,7 @@ def get_next_event(search_limit):
             return None
         else:
             # what time is it now?
-            current_time = datetime.datetime.now()
+            current_time = pytz.utc.localize( datetime.datetime.utcnow())
             # loop through the events in the list
             for event in event_list:
                 # we only care about events that have a start time
@@ -229,7 +231,7 @@ def get_next_event(search_limit):
                 if start:
                     # When does the appointment start?
                     # Convert the string it into a Python dateTime object so we can do math on it
-                    event_start = datetime.datetime.strptime(start, '%Y-%m-%dT%H:%M:%S-04:00')
+                    event_start = parser.parse(start)
                     # does the event start in the future?
                     if current_time < event_start:
                         # only use events that have a reminder set


### PR DESCRIPTION
Was hitting problems running the script in the UK (didn't like the hardcoded (`-04:00`) timezone in the `strptime`), switched to `dateutils` which has decent timezone handling (surprised the standard libs lack decent support..) and it's working nicely.
Thanks for sharing the project, it's a great idea.
